### PR TITLE
Update Prisma seeding to populate database with connecting cohort with user

### DIFF
--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -30,6 +30,8 @@ async function seed() {
 
   await createComment(post.id, student.id, 'Great post!')
 
+  await addUsersToCohort(cohort.id, student.id)
+
   process.exit(0)
 }
 
@@ -80,6 +82,34 @@ async function createCohort() {
   console.info('Cohort created', cohort)
 
   return cohort
+}
+
+async function addUsersToCohort(cohortId, userId) {
+  const cohort = await prisma.cohort.update({
+    where: { id: cohortId },
+    data: {
+      users: {
+        connect: { id: userId }
+      }
+    }
+  })
+
+  // Adding cohort to user
+  const user = await prisma.user.update({
+    where: { id: userId },
+    data: {
+      cohorts: {
+        connect: { id: cohortId }
+      }
+    }
+  })
+
+  console.log('-----')
+  console.log('Added user: ', user)
+  console.log('To cohort: ', cohort)
+  console.log('-----')
+
+  return { cohort, user }
 }
 
 async function createUser(


### PR DESCRIPTION
Has been tested (and working) using `npx prisma migrate reset` and then using the GET cohort endpoints to see that the user is successfully in the cohort.