### PR TITLE
Including 'specialism' field from users in all of the cohort endpoint…

### DIFF
--- a/src/domain/cohort.js
+++ b/src/domain/cohort.js
@@ -30,6 +30,7 @@ export async function getCohortById(cohortId) {
             id: true,
             role: true,
             email: true,
+            specialism: true,
             profile: {
               select: {
                 firstName: true,
@@ -58,6 +59,7 @@ export async function getAllCohorts() {
             id: true,
             role: true,
             email: true,
+            specialism: true,
             profile: {
               select: {
                 firstName: true,
@@ -105,6 +107,7 @@ export async function addUserToCohort(cohortId, userId) {
         id: true,
         role: true,
         email: true,
+        specialism: true,
         profile: {
           select: {
             firstName: true,
@@ -133,6 +136,7 @@ export async function deleteCohort(cohortId) {
             id: true,
             role: true,
             email: true,
+            specialism: true,
             profile: {
               select: {
                 firstName: true,
@@ -170,6 +174,7 @@ export async function updateCohort(cohortId, { name, startDate, endDate }) {
             id: true,
             role: true,
             email: true,
+            specialism: true,
             profile: {
               select: {
                 firstName: true,


### PR DESCRIPTION
Have now added to include the "specialism" field of the users in the cohort endpoint response bodies. For example GET /cohorts/1 returns:
```json
{
	"status": "success",
	"data": {
		"cohort": {
			"id": 1,
			"name": "Web Development 122222",
			"startDate": "2000-11-01T00:00:00.000Z",
			"endDate": "2001-12-01T00:00:00.000Z",
			"createdAt": "2024-10-31T11:18:59.541Z",
			"updatedAt": "2024-10-31T12:11:29.290Z",
			"users": [
				{
					"id": 1,
					"role": "STUDENT",
					"email": "student@test.com",
					"specialism": "Software Developer",
					"profile": {
						"firstName": "Joe",
						"lastName": "Bloggs",
						"bio": "Hello, world!",
						"githubUsername": ""
					}
				}
			]
		}
	}
}
```
Note that the "specialism" field is included. 
